### PR TITLE
mongodb is a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "MongoDB database adapter for ShareDB",
   "main": "index.js",
   "dependencies": {
-    "async": "^2.6.1"
+    "async": "^2.6.1",
+    "mongodb": "^3.1.0"
   },
   "peerDependencies": {
-    "mongodb": "^3.1.0",
     "@teamwork/sharedb": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
mongodb is a dependency, we may be more flexible in the version required but if mongodb is a peerDependency I'm not sure when dependency should be used in the nodejs ecosystem 
> peerDependencies is for dependencies that are exposed to (and expected to be used by) the consuming code, as opposed to "private" dependencies that are not exposed, and are only an implementation detail.